### PR TITLE
Remove timeout for the built-in php server

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php": ">=5.3"
     },
     "scripts": {
-        "start": "php -S 0.0.0.0:8181 -t samples"
+        "start": "composer run --timeout=0 serve",
+        "serve": "php -S 0.0.0.0:8181 -t samples"
     }
 }


### PR DESCRIPTION
Adding a hack to remove the timeout for the built-in PHP server